### PR TITLE
Feature: Fading Node Titles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
 			"license": "MIT",
 			"dependencies": {
 				"3d-force-graph": "^1.77.0",
-				"three": "^0.177.0"
+				"three": "^0.177.0",
+				"three-spritetext": "^1.10.0"
 			},
 			"devDependencies": {
 				"@types/node": "^16.11.6",
@@ -2677,6 +2678,18 @@
 			},
 			"peerDependencies": {
 				"three": ">=0.168"
+			}
+		},
+		"node_modules/three-spritetext": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/three-spritetext/-/three-spritetext-1.10.0.tgz",
+			"integrity": "sha512-t08iP1FCU1lQh8T5MmCpdijKgas8GDHJE0LqMGBuVu3xqMMpFnEZhTlih7FlxLPQizHIGoumUSpfOlY1GO/Tgg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"three": ">=0.86.0"
 			}
 		},
 		"node_modules/tinycolor2": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 	},
 	"dependencies": {
 		"3d-force-graph": "^1.77.0",
-		"three": "^0.177.0"
+		"three": "^0.177.0",
+		"three-spritetext": "^1.10.0"
 	}
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -146,6 +146,10 @@ export class Graph3DSettingsTab extends PluginSettingTab {
 		new Setting(containerEl).setName('Label text size').addSlider(s => s.setLimits(1, 10, 0.5).setValue(this.plugin.settings.labelTextSize).setDynamicTooltip()
 			.onChange(async (v) => { this.plugin.settings.labelTextSize = v; await this.plugin.saveSettings(); this.triggerUpdate({ updateDisplay: true }); }));
 		new Setting(containerEl).setName('Label text color').addColorPicker(c => c.setValue(this.plugin.settings.labelTextColor).onChange(async (v) => { this.plugin.settings.labelTextColor = v; await this.plugin.saveSettings(); this.triggerUpdate({ updateDisplay: true }); }));
+		// Added for Phase 3
+		new Setting(containerEl).setName('Prevent label occlusion').setDesc('Hides labels that are behind other nodes. Can impact performance on large graphs.')
+			.addToggle(toggle => toggle.setValue(this.plugin.settings.labelOcclusion)
+				.onChange(async (value) => { this.plugin.settings.labelOcclusion = value; await this.plugin.saveSettings(); }));
 
 
 		new Setting(containerEl).setName('Interaction').setHeading();

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -133,6 +133,21 @@ export class Graph3DSettingsTab extends PluginSettingTab {
 		new Setting(containerEl).setName('Link thickness').addSlider(s => s.setLimits(0.1, 5, 0.1).setValue(this.plugin.settings.linkThickness).setDynamicTooltip()
 			.onChange(async (v) => { this.plugin.settings.linkThickness = v; await this.plugin.saveSettings(); this.triggerUpdate({ updateDisplay: true }); }));
 
+		new Setting(containerEl).setName('Labels').setHeading();
+		new Setting(containerEl).setName('Show node labels').setDesc('Display the name of the node as a label.')
+			.addToggle(toggle => toggle.setValue(this.plugin.settings.showNodeLabels)
+				.onChange(async (value) => { this.plugin.settings.showNodeLabels = value; await this.plugin.saveSettings(); this.triggerUpdate({ updateDisplay: true }); }));
+		new Setting(containerEl).setName('Label distance').setDesc('How far away the camera can be before labels start to fade.')
+			.addSlider(s => s.setLimits(50, 500, 10).setValue(this.plugin.settings.labelDistance).setDynamicTooltip()
+				.onChange(async (v) => { this.plugin.settings.labelDistance = v; await this.plugin.saveSettings(); }));
+		new Setting(containerEl).setName('Label fade threshold').setDesc('The distance at which labels start to fade, as a percentage of the total label distance.')
+			.addSlider(s => s.setLimits(0.1, 1, 0.1).setValue(this.plugin.settings.labelFadeThreshold).setDynamicTooltip()
+				.onChange(async (v) => { this.plugin.settings.labelFadeThreshold = v; await this.plugin.saveSettings(); }));
+		new Setting(containerEl).setName('Label text size').addSlider(s => s.setLimits(1, 10, 0.5).setValue(this.plugin.settings.labelTextSize).setDynamicTooltip()
+			.onChange(async (v) => { this.plugin.settings.labelTextSize = v; await this.plugin.saveSettings(); this.triggerUpdate({ updateDisplay: true }); }));
+		new Setting(containerEl).setName('Label text color').addColorPicker(c => c.setValue(this.plugin.settings.labelTextColor).onChange(async (v) => { this.plugin.settings.labelTextColor = v; await this.plugin.saveSettings(); this.triggerUpdate({ updateDisplay: true }); }));
+
+
 		new Setting(containerEl).setName('Interaction').setHeading();
 		new Setting(containerEl).setName("Zoom on click").setDesc("Automatically zoom in on a node when it's clicked.")
 			.addToggle(toggle => toggle.setValue(this.plugin.settings.zoomOnClick)

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,7 @@ export interface Graph3DPluginSettings {
 	labelFadeThreshold: number;
 	labelTextSize: number;
 	labelTextColor: string;
+	labelOcclusion: boolean; // Added for Phase 3
 	// Interaction
 	zoomOnClick: boolean;
 	rotateSpeed: number;
@@ -82,6 +83,7 @@ export const DEFAULT_SETTINGS: Graph3DPluginSettings = {
 	labelFadeThreshold: 0.8,
 	labelTextSize: 2.5,
 	labelTextColor: '#ffffff',
+	labelOcclusion: false, // Added for Phase 3
 	// Interaction
 	zoomOnClick: true,
 	rotateSpeed: 1.0,

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,11 +8,16 @@ export interface GraphGroup {
 export enum NodeShape { Sphere = 'Sphere', Cube = 'Cube', Pyramid = 'Pyramid', Tetrahedron = 'Tetrahedron' }
 
 export interface Graph3DPluginSettings {
+	// Search
+	searchQuery: string;
+	showNeighboringNodes: boolean;
+	// Filters
 	showAttachments: boolean;
 	hideOrphans: boolean;
 	showTags: boolean;
-	searchQuery: string;
+	// Groups
 	groups: GraphGroup[];
+	// Display
 	useThemeColors: boolean;
 	colorNode: string;
 	colorTag: string;
@@ -20,29 +25,42 @@ export interface Graph3DPluginSettings {
 	colorLink: string;
 	colorHighlight: string;
 	backgroundColor: string;
+	// Appearance
 	nodeSize: number;
 	tagNodeSize: number;
 	attachmentNodeSize: number;
 	linkThickness: number;
-	centerForce: number;
-	repelForce: number;
-	linkForce: number;
 	nodeShape: NodeShape;
 	tagShape: NodeShape;
 	attachmentShape: NodeShape;
+	// Labels
+	showNodeLabels: boolean;
+	labelDistance: number;
+	labelFadeThreshold: number;
+	labelTextSize: number;
+	labelTextColor: string;
+	// Interaction
 	zoomOnClick: boolean;
-	showNeighboringNodes: boolean;
 	rotateSpeed: number;
 	panSpeed: number;
 	zoomSpeed: number;
+	// Forces
+	centerForce: number;
+	repelForce: number;
+	linkForce: number;
 }
 
 export const DEFAULT_SETTINGS: Graph3DPluginSettings = {
+	// Search
+	searchQuery: '',
+	showNeighboringNodes: true,
+	// Filters
 	showAttachments: false,
 	hideOrphans: false,
 	showTags: false,
-	searchQuery: '',
+	// Groups
 	groups: [],
+	// Display
 	useThemeColors: true,
 	colorNode: '#2080F0',
 	colorTag: '#9A49E8',
@@ -50,21 +68,29 @@ export const DEFAULT_SETTINGS: Graph3DPluginSettings = {
 	colorLink: '#666666',
 	colorHighlight: '#FFB800',
 	backgroundColor: '#0E0E10',
+	// Appearance
 	nodeSize: 1.5,
 	tagNodeSize: 1.0,
 	attachmentNodeSize: 1.2,
 	linkThickness: 1,
-	centerForce: 0.1,
-	repelForce: 10,
-	linkForce: 0.01,
 	nodeShape: NodeShape.Sphere,
 	tagShape: NodeShape.Tetrahedron,
 	attachmentShape: NodeShape.Cube,
+	// Labels
+	showNodeLabels: true,
+	labelDistance: 150,
+	labelFadeThreshold: 0.8,
+	labelTextSize: 2.5,
+	labelTextColor: '#ffffff',
+	// Interaction
 	zoomOnClick: true,
-	showNeighboringNodes: true,
 	rotateSpeed: 1.0,
 	panSpeed: 1.0,
 	zoomSpeed: 1.0,
+	// Forces
+	centerForce: 0.1,
+	repelForce: 10,
+	linkForce: 0.01,
 };
 
 export enum NodeType { File, Tag, Attachment }

--- a/src/view.ts
+++ b/src/view.ts
@@ -55,18 +55,23 @@ export class Graph3DView extends ItemView {
 		this.settings = plugin.settings;
 	}
 
-	getViewType() { return VIEW_TYPE_3D_GRAPH; }
-	getDisplayText() { return "3d graph"; }
+	getViewType() {
+		return VIEW_TYPE_3D_GRAPH;
+	}
+
+	getDisplayText() {
+		return "3d graph";
+	}
 
 	async onOpen() {
 		const rootContainer = this.contentEl;
 		rootContainer.empty();
 		rootContainer.addClass('graph-3d-view-content');
 
-		const viewWrapper = rootContainer.createEl('div', { cls: 'graph-3d-view-wrapper' });
+		const viewWrapper = rootContainer.createEl('div', {cls: 'graph-3d-view-wrapper'});
 
-		this.graphContainer = viewWrapper.createEl('div', { cls: 'graph-3d-container' });
-		this.messageEl = viewWrapper.createEl('div', { cls: 'graph-3d-message' });
+		this.graphContainer = viewWrapper.createEl('div', {cls: 'graph-3d-container'});
+		this.messageEl = viewWrapper.createEl('div', {cls: 'graph-3d-message'});
 
 		this.addLocalControls();
 		this.initializeGraph();
@@ -81,11 +86,11 @@ export class Graph3DView extends ItemView {
 	}
 
 	private addLocalControls() {
-		const controlsContainer = this.contentEl.createEl('div', { cls: 'graph-3d-controls-container' });
-		this.settingsToggleButton = controlsContainer.createEl('div', { cls: 'graph-3d-settings-toggle' });
+		const controlsContainer = this.contentEl.createEl('div', {cls: 'graph-3d-controls-container'});
+		this.settingsToggleButton = controlsContainer.createEl('div', {cls: 'graph-3d-settings-toggle'});
 		setIcon(this.settingsToggleButton, 'settings');
 		this.settingsToggleButton.setAttribute('aria-label', 'Graph settings');
-		this.settingsPanel = controlsContainer.createEl('div', { cls: 'graph-3d-settings-panel' });
+		this.settingsPanel = controlsContainer.createEl('div', {cls: 'graph-3d-settings-panel'});
 		this.settingsToggleButton.addEventListener('click', () => {
 			this.settingsPanel.classList.toggle('is-open');
 		});
@@ -116,7 +121,7 @@ export class Graph3DView extends ItemView {
 				.onChange(debounce(async (value) => {
 					this.settings.searchQuery = value.trim();
 					await this.plugin.saveSettings();
-					this.updateData({ useCache: true, reheat: false });
+					this.updateData({useCache: true, reheat: false});
 				}, 500, true)));
 
 		new Setting(container)
@@ -127,7 +132,7 @@ export class Graph3DView extends ItemView {
 					this.settings.showNeighboringNodes = value;
 					await this.plugin.saveSettings();
 					if (this.settings.searchQuery) {
-						this.updateData({ useCache: true, reheat: false });
+						this.updateData({useCache: true, reheat: false});
 					}
 				}));
 	}
@@ -140,7 +145,7 @@ export class Graph3DView extends ItemView {
 			.onChange(async (value) => {
 				this.settings.showTags = value;
 				await this.plugin.saveSettings();
-				this.updateData({ useCache: true, reheat: false });
+				this.updateData({useCache: true, reheat: false});
 			}));
 
 		new Setting(container).setName('Show attachments').addToggle(toggle => toggle
@@ -148,7 +153,7 @@ export class Graph3DView extends ItemView {
 			.onChange(async (value) => {
 				this.settings.showAttachments = value;
 				await this.plugin.saveSettings();
-				this.updateData({ useCache: true, reheat: false });
+				this.updateData({useCache: true, reheat: false});
 			}));
 
 		new Setting(container).setName('Hide orphans').addToggle(toggle => toggle
@@ -156,7 +161,7 @@ export class Graph3DView extends ItemView {
 			.onChange(async (value) => {
 				this.settings.hideOrphans = value;
 				await this.plugin.saveSettings();
-				this.updateData({ useCache: true, reheat: false });
+				this.updateData({useCache: true, reheat: false});
 			}));
 	}
 
@@ -201,7 +206,7 @@ export class Graph3DView extends ItemView {
 				.addButton(button => button
 					.setButtonText('Add new group')
 					.onClick(async () => {
-						this.settings.groups.push({ query: '', color: '#ffffff' });
+						this.settings.groups.push({query: '', color: '#ffffff'});
 						await this.plugin.saveSettings();
 						render();
 					}));
@@ -219,20 +224,41 @@ export class Graph3DView extends ItemView {
 		}
 
 		new Setting(container).setName('Node size').addSlider(s => s.setLimits(0.1, 5, 0.1).setValue(this.settings.nodeSize).setDynamicTooltip()
-			.onChange(async (v) => { this.settings.nodeSize = v; await updateDisplayAndColors(); }));
+			.onChange(async (v) => {
+				this.settings.nodeSize = v;
+				await updateDisplayAndColors();
+			}));
 		new Setting(container).setName('Tag node size').addSlider(s => s.setLimits(0.1, 5, 0.1).setValue(this.settings.tagNodeSize).setDynamicTooltip()
-			.onChange(async (v) => { this.settings.tagNodeSize = v; await updateDisplayAndColors(); }));
+			.onChange(async (v) => {
+				this.settings.tagNodeSize = v;
+				await updateDisplayAndColors();
+			}));
 		new Setting(container).setName('Attachment node size').addSlider(s => s.setLimits(0.1, 5, 0.1).setValue(this.settings.attachmentNodeSize).setDynamicTooltip()
-			.onChange(async (v) => { this.settings.attachmentNodeSize = v; await updateDisplayAndColors(); }));
+			.onChange(async (v) => {
+				this.settings.attachmentNodeSize = v;
+				await updateDisplayAndColors();
+			}));
 		new Setting(container).setName('Link thickness').addSlider(s => s.setLimits(0.1, 5, 0.1).setValue(this.settings.linkThickness).setDynamicTooltip()
-			.onChange(async (v) => { this.settings.linkThickness = v; await updateDisplayAndColors(); }));
+			.onChange(async (v) => {
+				this.settings.linkThickness = v;
+				await updateDisplayAndColors();
+			}));
 
 		new Setting(container).setName('Node shape').addDropdown(dd => dd.addOptions(NodeShape).setValue(this.settings.nodeShape)
-			.onChange(async(value: NodeShape) => {this.settings.nodeShape = value; await updateDisplayAndColors()}));
+			.onChange(async (value: NodeShape) => {
+				this.settings.nodeShape = value;
+				await updateDisplayAndColors()
+			}));
 		new Setting(container).setName('Tag shape').addDropdown(dd => dd.addOptions(NodeShape).setValue(this.settings.tagShape)
-			.onChange(async(value: NodeShape) => {this.settings.tagShape = value; await updateDisplayAndColors()}));
+			.onChange(async (value: NodeShape) => {
+				this.settings.tagShape = value;
+				await updateDisplayAndColors()
+			}));
 		new Setting(container).setName('Attachment shape').addDropdown(dd => dd.addOptions(NodeShape).setValue(this.settings.attachmentShape)
-			.onChange(async(value: NodeShape) => {this.settings.attachmentShape = value; await updateDisplayAndColors()}));
+			.onChange(async (value: NodeShape) => {
+				this.settings.attachmentShape = value;
+				await updateDisplayAndColors()
+			}));
 	}
 
 	private renderLabelSettings(container: HTMLElement) {
@@ -246,7 +272,7 @@ export class Graph3DView extends ItemView {
 					await this.plugin.saveSettings();
 
 					if (!value) {
-						this.graph.graphData().nodes.forEach((node: GraphNode) => this.cleanupNode(node, { cleanMesh: false }));
+						this.graph.graphData().nodes.forEach((node: GraphNode) => this.cleanupNode(node, {cleanMesh: false}));
 					}
 					this.updateDisplay();
 					this.updateColors();
@@ -306,7 +332,7 @@ export class Graph3DView extends ItemView {
 
 		const forceChangeHandler = async () => {
 			await this.plugin.saveSettings();
-			this.updateData({ useCache: false, reheat: true });
+			this.updateData({useCache: false, reheat: true});
 		};
 
 		new Setting(container)
@@ -364,18 +390,20 @@ export class Graph3DView extends ItemView {
 					}
 				});
 
-			this.graph.graphData({ nodes: [], links: [] });
+			this.graph.graphData({nodes: [], links: []});
 
 			this.initializeForces();
 			this.graph.pauseAnimation();
 			this.isGraphInitialized = true;
 
-			setTimeout(() => { this.updateData({ isFirstLoad: true }); }, 100);
+			setTimeout(() => {
+				this.updateData({isFirstLoad: true});
+			}, 100);
 		});
 	}
 
 	public async updateData(options: { useCache?: boolean; reheat?: boolean; isFirstLoad?: boolean } = {}) {
-		const { useCache = true, reheat = false, isFirstLoad = false } = options;
+		const {useCache = true, reheat = false, isFirstLoad = false} = options;
 
 		if (!this.isGraphInitialized || this.isUpdating) {
 			return;
@@ -387,7 +415,7 @@ export class Graph3DView extends ItemView {
 			if (useCache && this.graph.graphData().nodes.length > 0) {
 				this.graph.graphData().nodes.forEach((node: GraphNode) => {
 					if (node.id && node.x !== undefined && node.y !== undefined && node.z !== undefined) {
-						nodePositions.set(node.id, { x: node.x, y: node.y, z: node.z });
+						nodePositions.set(node.id, {x: node.x, y: node.y, z: node.z});
 					}
 				});
 			}
@@ -424,7 +452,7 @@ export class Graph3DView extends ItemView {
 							node.z = cachedPos.z;
 						} else {
 							const neighbors = adjacencyMap.get(node.id) || [];
-							let connectedNodePos: {x:number, y:number, z:number} | undefined;
+							let connectedNodePos: { x: number, y: number, z: number } | undefined;
 
 							for (const neighborId of neighbors) {
 								connectedNodePos = nodePositions.get(neighborId);
@@ -467,7 +495,7 @@ export class Graph3DView extends ItemView {
 				const Graph = (ForceGraph3D as any).default || ForceGraph3D;
 				this.graph = Graph()(this.graphContainer)
 					.onNodeClick((node: GraphNode) => this.handleNodeClick(node))
-					.graphData({ nodes: [], links: [] });
+					.graphData({nodes: [], links: []});
 
 				this.initializeForces();
 
@@ -552,7 +580,7 @@ export class Graph3DView extends ItemView {
 	}
 
 	private getNodeColor(node: GraphNode): string {
-		const { useThemeColors, colorHighlight, colorNode, colorTag, colorAttachment, groups } = this.settings;
+		const {useThemeColors, colorHighlight, colorNode, colorTag, colorAttachment, groups} = this.settings;
 
 		if (this.highlightedNodes.has(node.id)) {
 			return useThemeColors ? this.getCssColor('--graph-node-focused', colorHighlight) : colorHighlight;
@@ -621,19 +649,34 @@ export class Graph3DView extends ItemView {
 		let shape: NodeShape;
 		let size: number;
 		switch (node.type) {
-			case NodeType.Tag: shape = this.settings.tagShape; size = this.settings.tagNodeSize; break;
-			case NodeType.Attachment: shape = this.settings.attachmentShape; size = this.settings.attachmentNodeSize; break;
-			default: shape = this.settings.nodeShape; size = this.settings.nodeSize;
+			case NodeType.Tag:
+				shape = this.settings.tagShape;
+				size = this.settings.tagNodeSize;
+				break;
+			case NodeType.Attachment:
+				shape = this.settings.attachmentShape;
+				size = this.settings.attachmentNodeSize;
+				break;
+			default:
+				shape = this.settings.nodeShape;
+				size = this.settings.nodeSize;
 		}
 
 		let geometry: THREE.BufferGeometry;
 		const s = size * 1.5;
 
 		switch (shape) {
-			case NodeShape.Cube: geometry = new THREE.BoxGeometry(s, s, s); break;
-			case NodeShape.Pyramid: geometry = new THREE.ConeGeometry(s / 1.5, s, 4); break;
-			case NodeShape.Tetrahedron: geometry = new THREE.TetrahedronGeometry(s / 1.2); break;
-			default: geometry = new THREE.SphereGeometry(s / 2);
+			case NodeShape.Cube:
+				geometry = new THREE.BoxGeometry(s, s, s);
+				break;
+			case NodeShape.Pyramid:
+				geometry = new THREE.ConeGeometry(s / 1.5, s, 4);
+				break;
+			case NodeShape.Tetrahedron:
+				geometry = new THREE.TetrahedronGeometry(s / 1.2);
+				break;
+			default:
+				geometry = new THREE.SphereGeometry(s / 2);
 		}
 
 		const color = this.getNodeColor(node);
@@ -669,7 +712,7 @@ export class Graph3DView extends ItemView {
 	public updateForces() {
 		if (!this.isGraphInitialized) return;
 
-		const { centerForce, repelForce, linkForce } = this.settings;
+		const {centerForce, repelForce, linkForce} = this.settings;
 
 		if (this.centerForce) {
 			this.centerForce.strength(centerForce);
@@ -684,7 +727,7 @@ export class Graph3DView extends ItemView {
 
 	public updateControls() {
 		if (!this.isGraphInitialized) return;
-		const { rotateSpeed, panSpeed, zoomSpeed } = this.settings;
+		const {rotateSpeed, panSpeed, zoomSpeed} = this.settings;
 		const controls = this.graph.controls();
 		if (controls) {
 			controls.rotateSpeed = rotateSpeed;
@@ -752,11 +795,13 @@ export class Graph3DView extends ItemView {
 		if (!node) return;
 
 		if (this.clickTimeout) {
-			clearTimeout(this.clickTimeout); this.clickTimeout = null;
+			clearTimeout(this.clickTimeout);
+			this.clickTimeout = null;
 			this.handleNodeDoubleClick(node);
 		} else {
 			this.clickTimeout = setTimeout(() => {
-				this.handleNodeSingleClick(node); this.clickTimeout = null;
+				this.handleNodeSingleClick(node);
+				this.clickTimeout = null;
 			}, this.CLICK_DELAY);
 		}
 	}
@@ -821,8 +866,11 @@ export class Graph3DView extends ItemView {
 		this.updateColors();
 	}
 
-	private async processVaultData(): Promise<{ nodes: GraphNode[], links: { source: string, target: string }[] } | null> {
-		const { showAttachments, hideOrphans, showTags, searchQuery, showNeighboringNodes } = this.settings;
+	private async processVaultData(): Promise<{
+		nodes: GraphNode[],
+		links: { source: string, target: string }[]
+	} | null> {
+		const {showAttachments, hideOrphans, showTags, searchQuery, showNeighboringNodes} = this.settings;
 		const allFiles = this.app.vault.getFiles();
 		const resolvedLinks = this.app.metadataCache.resolvedLinks;
 		if (!resolvedLinks) return null;
@@ -839,14 +887,14 @@ export class Graph3DView extends ItemView {
 				content = await this.app.vault.cachedRead(file);
 			}
 
-			allNodesMap.set(file.path, { id: file.path, name: file.basename, filename: file.name, type, tags, content });
+			allNodesMap.set(file.path, {id: file.path, name: file.basename, filename: file.name, type, tags, content});
 		}
 
 
 		const allLinks: { source: string, target: string }[] = [];
 		for (const sourcePath in resolvedLinks) {
 			for (const targetPath in resolvedLinks[sourcePath]) {
-				allLinks.push({ source: sourcePath, target: targetPath });
+				allLinks.push({source: sourcePath, target: targetPath});
 			}
 		}
 
@@ -857,9 +905,9 @@ export class Graph3DView extends ItemView {
 					node.tags.forEach(tagName => {
 						const tagId = `tag:${tagName}`;
 						if (!allTags.has(tagName)) {
-							allTags.set(tagName, { id: tagId, name: `#${tagName}`, type: NodeType.Tag });
+							allTags.set(tagName, {id: tagId, name: `#${tagName}`, type: NodeType.Tag});
 						}
-						allLinks.push({ source: node.id, target: tagId });
+						allLinks.push({source: node.id, target: tagId});
 					});
 				}
 			});
@@ -923,10 +971,10 @@ export class Graph3DView extends ItemView {
 			linksToShow = linksToShow.filter(l => visibleNodeIds.has(l.source) && visibleNodeIds.has(l.target));
 		}
 
-		return { nodes: nodesToShow, links: linksToShow };
+		return {nodes: nodesToShow, links: linksToShow};
 	}
 
-	private cleanupNode(node: GraphNode, options: { cleanMesh?: boolean } = { cleanMesh: true }) {
+	private cleanupNode(node: GraphNode, options: { cleanMesh?: boolean } = {cleanMesh: true}) {
 		if (options.cleanMesh) {
 			const mesh = this.nodeMeshes.get(node);
 			if (mesh) {
@@ -965,3 +1013,5 @@ export class Graph3DView extends ItemView {
 		if (this.messageEl) {
 			this.messageEl.remove();
 		}
+	}
+}


### PR DESCRIPTION
This PR implements the "Fading Node Titles" feature based on the development roadmap, initially suggested by @Roebler. It adds configurable, distance-based text labels to nodes, which fade smoothly and can be hidden to prevent occlusion by other nodes.

**Changes Implemented:**

- **Phase 1: Foundational Implementation**

  - Modified `createNodeObject` to attach a `SpriteText` label to a `THREE.Group` for each node, caching references for efficient updates.

  - Hooked into the render loop using the `.onEngineTick()` function to continuously update label visibility.

- **Phase 2: User Interface & Experience**

  - Added new settings to `types.ts` and `settings.ts` for:

     - Toggling labels on/off (`showNodeLabels`)

     - Controlling visibility distance (`labelDistance`)

     - Adjusting the fade point (`labelFadeThreshold`)

     - Customizing text size and color.

  - Integrated UI controls (toggles, sliders, color picker) into the main plugin settings tab.

  - Upgraded the `updateLabels` function from a simple toggle to calculating opacity for a smooth, gradual fade effect based on camera distance.

- **Phase 3: Advanced Refinement**

  - Added a `labelOcclusion` setting to `types.ts` and a toggle to the settings UI.

  - Implemented raycasting within the `updateLabels` function. If enabled, a ray is cast from the camera to the node to check if another node is obstructing the view, hiding the label if so.

  - Moved the three most important controls (`Show node labels`, `Label distance`, and `Prevent label occlusion`) to the in-view "quick settings" panel for a better user experience, as requested.
  
  
  This PR will close #8

## Summary by Sourcery

Implement fading node titles feature by rendering text labels on nodes with distance-based opacity, optional occlusion hiding, corresponding UI controls, and performance optimizations

New Features:
- Add sprite-based text labels to nodes with configurable distance-based fading and smooth opacity transitions
- Implement optional occlusion detection via raycasting to hide labels behind other nodes
- Add plugin settings and UI controls for toggling labels, setting fade distance and threshold, customizing text size and color, and enabling occlusion prevention

Enhancements:
- Cache node meshes and label sprites in WeakMaps, throttle label updates, and clean up objects for improved performance
- Expose key label settings in the in-view quick settings panel for streamlined user access

Build:
- Add three-spritetext dependency for rendering node labels